### PR TITLE
Add defer Close() in redis test

### DIFF
--- a/redis/redis_test.go
+++ b/redis/redis_test.go
@@ -13,6 +13,7 @@ func TestRedisCache(t *testing.T) {
 		// TODO: rather than skip the test, fall back to a faked redis server
 		t.Skipf("skipping test; no server running at localhost:6379")
 	}
+	defer conn.Close()
 	conn.Do("FLUSHALL")
 
 	test.Cache(t, NewWithClient(conn))


### PR DESCRIPTION
## Summary
- ensure redis connections are closed in tests

## Testing
- `go vet ./...` *(fails: directory prefix does not contain module)*
- `go test ./redis` *(fails: cannot find main module)*


------
https://chatgpt.com/codex/tasks/task_e_683fe77932f483238b9d2c534adf7ad9